### PR TITLE
Organize GoPro files into group directories

### DIFF
--- a/join_gopro_360.py
+++ b/join_gopro_360.py
@@ -40,45 +40,16 @@ for group_id, group_files in groups.items():
 
     group_files.sort()
 
-    filelist_path = joined_files_dir / f"filelist_{group_id}.txt"
-    with filelist_path.open("w", encoding="utf-8") as f:
-        for filename in group_files:
-            abs_path = Path(filename).resolve()
-            f.write(f"file '{abs_path.as_posix()}'\n")
+    # Create directory for this group
+    group_dir = Path(group_id)
+    group_dir.mkdir(exist_ok=True)
 
-    temp_output = Path(f"temp_{group_id}.mp4")
-    final_output = Path(f"{group_id}.360")
-
-    subprocess.run([
-        ffmpeg_path, "-y",
-        "-f", "concat", "-safe", "0",
-        "-i", str(filelist_path),
-        "-c", "copy",
-        "-ignore_unknown",
-        "-map", "0:0", "-map", "0:1", "-map", "0:3", "-map", "0:5",
-        str(temp_output)
-    ], check=True)
-
-    first_file = Path(group_files[0]).resolve()
-    result = subprocess.run([
-        str(udtacopy_path),
-        str(first_file),
-        str(temp_output)
-    ], check=False)
-
-    if result.returncode not in (0, 1):
-        raise RuntimeError(f"udtacopy failed for group {group_id} with code {result.returncode}")
-
-    temp_output.rename(final_output)
-
-    # Set output timestamps to match first input file
-    first_stat = os.stat(first_file)
-    os.utime(final_output, (first_stat.st_atime, first_stat.st_mtime))
-
-    # Move source files to joined_files/
+    # Move all files for this group into the directory
     for filename in group_files:
-        shutil.move(filename, joined_files_dir / filename)
+        source_path = Path(filename)
+        dest_path = group_dir / filename
+        shutil.move(str(source_path), str(dest_path))
 
-    print(f"Finished: {final_output}")
+    print(f"Finished: Created directory {group_id}/ with {len(group_files)} file(s)")
 
 print("All groups processed.")


### PR DESCRIPTION
Changed functionality to not join files at all, but only create a directory for each group of files and move the files into their respective directories.